### PR TITLE
Remove build annotation from EventCreationRequest

### DIFF
--- a/src/main/java/com/paulograbin/confirmation/usecases/event/creation/EventCreationRequest.java
+++ b/src/main/java/com/paulograbin/confirmation/usecases/event/creation/EventCreationRequest.java
@@ -1,14 +1,12 @@
 package com.paulograbin.confirmation.usecases.event.creation;
 
 import com.paulograbin.confirmation.domain.User;
-import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalTime;
 
 
 @Data
-@Builder(setterPrefix = "with")
 public class EventCreationRequest {
 
     private String title;

--- a/src/test/java/com/paulograbin/confirmation/usecases/event/creation/EventCreationUseCaseTest.java
+++ b/src/test/java/com/paulograbin/confirmation/usecases/event/creation/EventCreationUseCaseTest.java
@@ -38,15 +38,15 @@ class EventCreationUseCaseTest {
     }
 
     private EventCreationRequest makeValidRequest() {
-        EventCreationRequest.EventCreationRequestBuilder builder = EventCreationRequest.builder();
-        builder.withTitle("Title");
-        builder.withDescription("aaaaaa");
-        builder.withAddress("Title");
-        builder.withDate(DateHelper.makeFutureDate());
-        builder.withTime(LocalTime.now());
-        builder.withCreator(makeCreator());
+        EventCreationRequest request = new EventCreationRequest();
+        request.setTitle("Title");
+        request.setDescription("aaaaaa");
+        request.setAddress("Title");
+        request.setDate(DateHelper.makeFutureDate());
+        request.setTime(LocalTime.now());
+        request.setCreator(makeCreator());
 
-        return builder.build();
+        return request;
     }
 
     @Test


### PR DESCRIPTION
Because it removed the default constructor causing events to not be created